### PR TITLE
Implement goroutine to delete posts from DB every 2 hours

### DIFF
--- a/cmd/ingest/ingest.go
+++ b/cmd/ingest/ingest.go
@@ -159,6 +159,15 @@ func (w *WebSocketManager) readPump(ctx context.Context) {
 	}
 }
 
+func cleanUpDb(pr *db.PostRepository) {
+	for {
+		timer := time.After(2 * time.Hour)
+		<-timer
+		log.Printf("Cleaning up posts...")
+		pr.DeletePosts()
+	}
+}
+
 func main() {
 	fmt.Println("Starting DB...")
 
@@ -170,6 +179,8 @@ func main() {
 	defer database.Close()
 
 	pr := db.NewPostRepository(database)
+
+	go cleanUpDb(pr)
 
 	postTableColumns := map[string]string{
 		"id":                "INTEGER PRIMARY KEY AUTOINCREMENT",

--- a/db/db.go
+++ b/db/db.go
@@ -249,7 +249,9 @@ func (pr *PostRepository) DeletePost(uuid string) error {
 func (pr *PostRepository) DeletePosts() error {
 	pr.lock.Lock()
 	defer pr.lock.Unlock()
-	sqlStmt := `DELETE FROM table_name WHERE NOT EXISTS (
+
+	log.Printf("Deleting old posts...")
+	sqlStmt := `DELETE FROM posts WHERE NOT EXISTS (
     SELECT 1 FROM (
         SELECT * FROM posts ORDER BY time_us DESC LIMIT 10
     ) AS temp WHERE posts.did = temp.did AND posts.time_us = temp.time_us

--- a/db/db.go
+++ b/db/db.go
@@ -249,7 +249,11 @@ func (pr *PostRepository) DeletePost(uuid string) error {
 func (pr *PostRepository) DeletePosts() error {
 	pr.lock.Lock()
 	defer pr.lock.Unlock()
-	sqlStmt := `DELETE FROM posts;`
+	sqlStmt := `DELETE FROM table_name WHERE NOT EXISTS (
+    SELECT 1 FROM (
+        SELECT * FROM posts ORDER BY time_us DESC LIMIT 10
+    ) AS temp WHERE posts.did = temp.did AND posts.time_us = temp.time_us
+	);`
 
 	_, err := pr.db.Exec(sqlStmt)
 	if err != nil {

--- a/handlers/post.go
+++ b/handlers/post.go
@@ -80,20 +80,7 @@ func (ps *PostService) PostWriteHandler(w http.ResponseWriter, r *http.Request) 
 
 }
 
-func (ps *PostService) PostDeleteHandler(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
-	if err := ps.PostRepository.DeletePost(id); err != nil {
-		log.Printf("Failed to delete post: %s because %v", id, err)
-		w.WriteHeader(500)
-		return
-	}
-	log.Printf("Deleted post %s\n", id)
-
-	w.WriteHeader(http.StatusOK)
-
-}
-
-func (ps *PostService) PostsDeleteHandler(w http.ResponseWriter, r *http.Request) {
+func (ps *PostService) DeletePosts(w http.ResponseWriter, r *http.Request) {
 	if err := ps.PostRepository.DeletePosts(); err != nil {
 		log.Printf("Failed to delete post because %v", err)
 		w.WriteHeader(500)

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -11,8 +11,6 @@ func CreateRoutes(postService *handlers.PostService) {
 	http.Handle("GET /", fs)
 
 	/*Post Routes*/
-	http.HandleFunc("DELETE /api/v1/post/{id}", postService.PostDeleteHandler)
-	http.HandleFunc("DELETE /api/v1/posts", postService.PostsDeleteHandler)
 	http.HandleFunc("GET /api/v1/post/{id}", postService.PostGetHandler)
 
 	http.HandleFunc("GET /api/v1/posts", postService.PostsGetHandler)


### PR DESCRIPTION
## What's changing

The gitfeed server currently is currently tiny runs into performance issues at query-time, even after some tuning. We've added DB indexes for performance tuning, but we also need to delete old records to not fill up the server, specifically since the feed is meant to be mostly stateless and temporal. 

We implement a `goroutine` that deletes all except the top 10 posts ordered by time from the DB every 2 hours and remove API routes for deletion until we can implement auth. 

