### PR TITLE
Remove redundant repo URL display in feed posts

### DIFF
--- a/static/feed.js
+++ b/static/feed.js
@@ -201,8 +201,6 @@ export async function fetchPosts() {
             const repoHeader = card.querySelector('.repo-header');
             const repoUrl = card.querySelector('.post-link a').getAttribute('href');
             console.log("RepoURL " + repoUrl)
-            let link = `<a href="$repoUrl" target="_blank" rel="noopener noreferrer">${repoUrl}</a>`
-            repoHeader.innerHTML = link;
             const githubMatch = isGithubRepo(repoUrl);
             if (githubMatch && githubMatch[0]) {
                 try {
@@ -212,6 +210,8 @@ export async function fetchPosts() {
                     console.error('Error fetching GitHub data for post:', error);
                 }
             } else {
+                let link = `<a href="$repoUrl" target="_blank" rel="noopener noreferrer">${repoUrl}</a>`
+                repoHeader.innerHTML = link;
                 continue;
             }
         }


### PR DESCRIPTION
Removes the repetition of displaying the repository URL for each post in the feed, instead choosing to display it only if the link is from a GitHub repo.
 
Follow-up to fix https://github.com/veekaybee/gitfeed/pull/7